### PR TITLE
fix MDSplot based on limma commit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DAMEfinder
 Type: Package
 Title: Finds DAMEs - Differential Allelicly MEthylated regions
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: c(person("Stephany", "Orjuela", role = c("aut", "cre"), 
            email = "sorjuelal@gmail.com", comment = c(ORCID = "0000-0002-1508-461X")),
              person("Dania", "Machlab", role = "aut", email = "dania.machlab@gmail.com"),

--- a/R/methyl_MDS_plot.R
+++ b/R/methyl_MDS_plot.R
@@ -37,8 +37,10 @@ methyl_MDS_plot <- function(x, group, top = 1000, coverage = 5,
             assays(x)[["cov"]] >= 
             coverage) == BiocGenerics::ncol(x), ]
         
+        #mds_meth <- limma::plotMDS(asm.red, top = top, 
+        #                            plot = FALSE)$cmdscale.out
         mds_meth <- limma::plotMDS(asm.red, top = top, 
-                                    plot = FALSE)$cmdscale.out
+                                    plot = FALSE)$eigen.vectors
         
     } else {
         
@@ -56,7 +58,7 @@ methyl_MDS_plot <- function(x, group, top = 1000, coverage = 5,
             methsTR <- methsTR[!bad, , drop = FALSE]
         
         mds_meth <- limma::plotMDS(methsTR, top = top, 
-                                    plot = FALSE)$cmdscale.out
+                                    plot = FALSE)$eigen.vectors
     }
     
     df <- data.frame(dim1 = mds_meth[, 1], dim2 = mds_meth[, 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,12 @@
 \name{NEWS}
 \title{News for Package 'DAMEfinder'}
 
+\section{DAMEfinder VERSION 1.3.1}{
+\itemize{
+    \item change cmdscale.out for eigen.vectors in methyl_MDS_plot
+}
+}
+
 
 \section{DAMEfinder VERSION 1.3.0}{
 \itemize{


### PR DESCRIPTION
Change required based on:

   commit 1e27129c2640f8e7112844715037c345c59e1312
   Author: Gordon Smyth <smyth@wehi.edu.au>
   Date:   Sun Mar 28 16:08:37 2021 +1100

     28 Mar 2021: limma 3.47.12

     - Rewrite the MDS calculations performed by plotMDS(). The function no
       longer calls cmdscale() but instead performs the necessary
       eigenvector computations directly. Proportion of variance explained
       by each dimension is now computed. The `ndim` argument is now
       removed. All eigenvectors are now stored so that plotMDS.MDS does
       not need to recompute them if different dimensions are requested.